### PR TITLE
lowercase keys

### DIFF
--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -21,7 +21,7 @@ pub(crate) fn str_to_key(input: &str) -> Result<CompoundKey, ConfigurationError>
                 Err(e) => return Err(ErrorCode::ParsingError(format!("Error occured while parsing `{}` : {}", trimmed_key, e.to_string())).into()),
             }
         } else {
-            result.push(Key::Map(trimmed_key.to_owned()))
+            result.push(Key::Map(trimmed_key.to_ascii_lowercase()))
         }
     }
 


### PR DESCRIPTION
use forced lowercase configuration keys - this solves the problem of having case sensitive keys.

i usually define all my env vars all uppercase, but when i try to convert my settings to a struct, it tries to use lowercase keys for resolving.

manually converting them lowercase by default makes it rustfmt compatible (uppercase keys in a struct produce a warning) but also makes it compatible with using lowercase keys in config files and uppercase in env.

if a global lowercase conversion isnt wanted, one could convert all the env keys to lowercase instead.